### PR TITLE
works with older angular

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@types/lodash.frompairs": "^4.0.2",
     "@types/react": "^16.0.0",
     "@types/react-dom": "^15.5.1",
-    "angular": ">=1.6.5",
+    "angular": ">=1.5.8",
     "lodash.frompairs": "^4.0.1",
     "ngcomponent": "^3.0.2"
   }

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@types/lodash.frompairs": "^4.0.2",
     "@types/react": "^16.0.0",
     "@types/react-dom": "^15.5.1",
-    "angular": ">=1.5.8",
+    "angular": ">=1.5.11",
     "lodash.frompairs": "^4.0.1",
     "ngcomponent": "^3.0.2"
   }


### PR DESCRIPTION
This actually runs fine on older versions of angular. We are currently running it with Angular 1.5.11. 
However, for some strange reason, requiring an older version breaks ngSanitize! (ngSanitize tries to bind against the react2angular version). 

Connected to https://github.com/coatue-oss/react2angular/issues/38