### PR TITLE
Add injectNames to use DI in react2angular

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -17,7 +17,8 @@ import { render, unmountComponentAtNode } from 'react-dom'
  */
 export function react2angular<Props>(
   Class: React.ComponentClass<Props> | React.SFC<Props>,
-  bindingNames?: (keyof Props)[]
+  bindingNames: (keyof Props)[] | null = null,
+  injectNames: string[] = []
 ): IComponentOptions {
   const names = bindingNames
     || (Class.propTypes && Object.keys(Class.propTypes))
@@ -25,13 +26,15 @@ export function react2angular<Props>(
 
   return {
     bindings: fromPairs(names.map(_ => [_, '<'])),
-    controller: ['$element', class extends NgComponent<Props> {
-      constructor(private $element: IAugmentedJQuery) {
+    controller: ['$element', ...(injectNames as any), class extends NgComponent<Props> {
+      injectedProps: any[];
+      constructor(private $element: IAugmentedJQuery, ...injectedProps: any[]) {
         super()
+        this.injectedProps = injectedProps;
       }
       render() {
         // TODO: rm any when https://github.com/Microsoft/TypeScript/pull/13288 is merged
-        render(<Class {...(this.props as any)} />, this.$element[0])
+        render(<Class {...(this.props as any)} {...this.injectedProps} />, this.$element[0])
       }
       componentWillUnmount() {
         unmountComponentAtNode(this.$element[0])

--- a/index.tsx
+++ b/index.tsx
@@ -34,7 +34,7 @@ export function react2angular<Props>(
       }
       render() {
         // TODO: rm any when https://github.com/Microsoft/TypeScript/pull/13288 is merged
-        render(<Class {...(this.props as any)} {...this.injectedProps} />, this.$element[0])
+        render(<Class {...this.injectedProps} {...(this.props as any)} />, this.$element[0])
       }
       componentWillUnmount() {
         unmountComponentAtNode(this.$element[0])

--- a/index.tsx
+++ b/index.tsx
@@ -26,7 +26,7 @@ export function react2angular<Props>(
 
   return {
     bindings: fromPairs(names.map(_ => [_, '<'])),
-    controller: ['$element', ...(injectNames as any), class extends NgComponent<Props> {
+    controller: ['$element', ...injectNames, class extends NgComponent<Props> {
       injectedProps: any[];
       constructor(private $element: IAugmentedJQuery, ...injectedProps: any[]) {
         super()

--- a/index.tsx
+++ b/index.tsx
@@ -27,10 +27,13 @@ export function react2angular<Props>(
   return {
     bindings: fromPairs(names.map(_ => [_, '<'])),
     controller: ['$element', ...injectNames, class extends NgComponent<Props> {
-      injectedProps: any[];
+      injectedProps: { [name: string]: any }
       constructor(private $element: IAugmentedJQuery, ...injectedProps: any[]) {
         super()
-        this.injectedProps = injectedProps;
+        this.injectedProps = {}
+        injectNames.forEach((name, i) => {
+          this.injectedProps[name] = injectedProps[i]
+        })
       }
       render() {
         // TODO: rm any when https://github.com/Microsoft/TypeScript/pull/13288 is merged

--- a/test.tsx
+++ b/test.tsx
@@ -93,7 +93,7 @@ class TestSix extends React.Component<any> {
 
 class TestSeven extends React.Component<any> {
   static propTypes = {
-    foo: React.PropTypes.string.isRequired
+    foo: PropTypes.string.isRequired
   }
 
   render() {

--- a/test.tsx
+++ b/test.tsx
@@ -115,6 +115,18 @@ describe('react2angular', () => {
     it('should have empty bindings when parameter is not passed', () => {
       expect(react2angular(TestThree).bindings).toEqual({})
     })
+
+    it('should use the injectNames for DI', () => {
+      const defaultDi = (react2angular(TestThree).controller as any).slice(0, -1)
+      const injectedDi = (react2angular(TestThree, null, ['foo', 'bar']).controller as any).slice(0, -1)
+      expect(injectedDi).toEqual(defaultDi.concat(['foo', 'bar']))
+    })
+
+    it('should have default DI specifications if injectNames is empty', () => {
+      const defaultDi = (react2angular(TestThree).controller as any).slice(0, -1)
+      const injectedDi = (react2angular(TestThree, null, []).controller as any).slice(0, -1)
+      expect(injectedDi).toEqual(defaultDi)
+    })
   })
 
   describe('react classes', () => {


### PR DESCRIPTION
Currently react2angular cannot use the DI system of AngularJS.
In this PR I added `injectNames` to react2angular to specify injectables to converted components.

When I do this:

```js
angular.component(react2angular(ReactComponent, null, ['$window', '$location']))
```

then injected items will be passed to the props like this:

```js
const ReactComponent = ({ $window, $location }) => (
  <ul>
    <li>window size : {$window.innerWidth} x {$window.innerHeight}</li>
    <li>location.href : {$location.href}</li>  
  </ul>
)
```

This PR is based on #48 in order to run tests locally.
Commits before 1a3ae9f is not necessary for this PR.