### PR TITLE
Use optional binding - less watchers for complex components

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ class MyComponent extends Component {
 angular
   .module('myModule', [])
   .constant('FOO', 'FOO!')
-  .component('myComponent', react2angular(MyComponent, [], ['$http', 'FOO'))
+  .component('myComponent', react2angular(MyComponent, [], ['$http', 'FOO', {name:'baz', optional:true}))
 ```
 
 ## Tests

--- a/index.tsx
+++ b/index.tsx
@@ -17,15 +17,15 @@ import { render, unmountComponentAtNode } from 'react-dom'
  */
 export function react2angular<Props>(
   Class: React.ComponentClass<Props> | React.SFC<Props>,
-  bindingNames: (keyof Props)[] | null = null,
+  bindingNames: {name: string, optional:boolean}[] | string[] | null = null,
   injectNames: string[] = []
 ): IComponentOptions {
-  const names = bindingNames
-    || (Class.propTypes && Object.keys(Class.propTypes))
+  const names: {name:string, optional:boolean}[] = (bindingNames && (bindingNames as any[]).map(_ => _.name?_:{name:_, optional: false}))
+    || (Class.propTypes && Object.keys(Class.propTypes).map(_ => ({name: _, optional: !Class.propTypes[_].isRequired})))
     || []
 
   return {
-    bindings: fromPairs(names.map(_ => [_, '<?'])),
+    bindings: fromPairs(names.map(_ => [_.name, _.optional?'<?':'<'])),
     controller: ['$element', ...injectNames, class extends NgComponent<Props> {
       injectedProps: { [name: string]: any }
       constructor(private $element: IAugmentedJQuery, ...injectedProps: any[]) {

--- a/index.tsx
+++ b/index.tsx
@@ -21,7 +21,7 @@ export function react2angular<Props>(
   injectNames: string[] = []
 ): IComponentOptions {
   const names: {name:string, optional:boolean}[] = (bindingNames && (bindingNames as any[]).map(_ => _.name?_:{name:_, optional: false}))
-    || (Class.propTypes && Object.keys(Class.propTypes).map(_ => ({name: _, optional: !Class.propTypes[_].isRequired})))
+    || (Class.propTypes && Object.keys(Class.propTypes).map(_ => ({name: _, optional: !(Class.propTypes[_] as any).isRequired})))
     || []
 
   return {

--- a/index.tsx
+++ b/index.tsx
@@ -25,7 +25,7 @@ export function react2angular<Props>(
     || []
 
   return {
-    bindings: fromPairs(names.map(_ => [_, '<'])),
+    bindings: fromPairs(names.map(_ => [_, '<?'])),
     controller: ['$element', ...injectNames, class extends NgComponent<Props> {
       injectedProps: { [name: string]: any }
       constructor(private $element: IAugmentedJQuery, ...injectedProps: any[]) {

--- a/index.tsx
+++ b/index.tsx
@@ -2,6 +2,7 @@ import { IAugmentedJQuery, IComponentOptions } from 'angular'
 import fromPairs = require('lodash.frompairs')
 import NgComponent from 'ngcomponent'
 import * as React from 'react'
+import * as PropTypes from 'prop-types'
 import { render, unmountComponentAtNode } from 'react-dom'
 
 /**
@@ -15,13 +16,14 @@ import { render, unmountComponentAtNode } from 'react-dom'
  *   const AngularComponent = react2angular(ReactComponent, ['foo'])
  *   ```
  */
+
 export function react2angular<Props>(
   Class: React.ComponentClass<Props> | React.SFC<Props>,
-  bindingNames: ({name: string, optional:boolean}|string)[] | null = null,
+  bindingNames: ({name: (keyof Props), optional:boolean}|(keyof Props))[] | null = null,
   injectNames: string[] = []
 ): IComponentOptions {
   const names: {name:string, optional:boolean}[] = (bindingNames && (bindingNames as any[]).map(_ => _.name?_:{name:_, optional: false}))
-    || (Class.propTypes && Object.keys(Class.propTypes).map(_ => ({name: _, optional: !(Class.propTypes[_] as any).isRequired})))
+    || (Class.propTypes && Object.keys(Class.propTypes).map((_:keyof Props) => ({name: _, optional: !!((Class.propTypes as React.ValidationMap<Props>)[_] as PropTypes.Requireable<Props>).isRequired})))
     || []
 
   return {

--- a/index.tsx
+++ b/index.tsx
@@ -17,7 +17,7 @@ import { render, unmountComponentAtNode } from 'react-dom'
  */
 export function react2angular<Props>(
   Class: React.ComponentClass<Props> | React.SFC<Props>,
-  bindingNames: {name: string, optional:boolean}[] | string[] | null = null,
+  bindingNames: ({name: string, optional:boolean}|string)[] | null = null,
   injectNames: string[] = []
 ): IComponentOptions {
   const names: {name:string, optional:boolean}[] = (bindingNames && (bindingNames as any[]).map(_ => _.name?_:{name:_, optional: false}))

--- a/test.tsx
+++ b/test.tsx
@@ -153,8 +153,8 @@ describe('react2angular', () => {
       const reactAngularComponent = react2angular(TestFive)
 
       expect(reactAngularComponent.bindings).toEqual({
-        bar: '<',
-        baz: '<',
+        bar: '<?',
+        baz: '<?',
         foo: '<'
       })
     })
@@ -163,7 +163,7 @@ describe('react2angular', () => {
       const reactAngularComponent = react2angular(TestFive, ['foo'])
 
       expect(reactAngularComponent.bindings).toEqual({
-        foo: '<'
+        foo: '<?'
       })
     })
 

--- a/test.tsx
+++ b/test.tsx
@@ -179,7 +179,9 @@ describe('react2angular', () => {
                                                              'baz'])
 
       expect(reactAngularComponent.bindings).toEqual({
-        foo: '<'
+        foo: '<?',
+        bar: '<',
+        baz: '<'
       })
 
     })

--- a/test.tsx
+++ b/test.tsx
@@ -39,7 +39,10 @@ class TestFive extends React.Component<Props> {
   static propTypes = {
     bar: PropTypes.array.isRequired,
     baz: PropTypes.func.isRequired,
-    foo: PropTypes.number.isRequired
+    foo: PropTypes.number.isRequired,
+    baropt: PropTypes.array,
+    bazopt: PropTypes.func,
+    fooopt: PropTypes.number,
   }
 
   render() {
@@ -153,9 +156,12 @@ describe('react2angular', () => {
       const reactAngularComponent = react2angular(TestFive)
 
       expect(reactAngularComponent.bindings).toEqual({
-        bar: '<?',
-        baz: '<?',
-        foo: '<?'
+        bar: '<',
+        baz: '<',
+        foo: '<',
+        baropt: '<?',
+        bazopt:'<?',
+        fooopt:'<?'
       })
     })
 
@@ -163,8 +169,19 @@ describe('react2angular', () => {
       const reactAngularComponent = react2angular(TestFive, ['foo'])
 
       expect(reactAngularComponent.bindings).toEqual({
-        foo: '<?'
+        foo: '<'
       })
+    })
+
+    it('should accept optional and required bindings', ()=>{
+      const reactAngularComponent = react2angular(TestFive, [{name: 'foo', optional:true},
+                                                             {name: 'bar', optional:false},
+                                                             'baz'])
+
+      expect(reactAngularComponent.bindings).toEqual({
+        foo: '<'
+      })
+
     })
 
     it('should have empty bindings when parameter is an empty array', () => {

--- a/test.tsx
+++ b/test.tsx
@@ -155,7 +155,7 @@ describe('react2angular', () => {
       expect(reactAngularComponent.bindings).toEqual({
         bar: '<?',
         baz: '<?',
-        foo: '<'
+        foo: '<?'
       })
     })
 


### PR DESCRIPTION
By switching from required bindings to optional ones the performance of complex components is greatly increased. I had a page where I had to have multiple datepickers, but they each had 72 watchers even though I was only passing 1 dynamic binding. By switching to optional bindings this dropped to 2.