### PR TITLE
Add $$ngIsClass class accessor to support older browsers

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -27,6 +27,9 @@ export function react2angular<Props>(
   return {
     bindings: fromPairs(names.map(_ => [_, '<'])),
     controller: ['$element', ...injectNames, class extends NgComponent<Props> {
+      static get $$ngIsClass() {
+        return true;
+      }
       injectedProps: { [name: string]: any }
       constructor(private $element: IAugmentedJQuery, ...injectedProps: any[]) {
         super()


### PR DESCRIPTION
Originally filed at https://bugzilla.mozilla.org/show_bug.cgi?id=1458017

react2angular doesn't work on Firefox ESR 52.7.4, because angular.js's injector.js requires [Function.prototype.toString revision](https://tc39.github.io/Function-prototype-toString-revision/), and it's not supported on that version.

This can be fixed by defining $$ngIsClass on the class, to skip the following branch:
https://github.com/angular/angular.js/blob/a7e5e83240f9539ffa0d4b429d30440c11775e76/src/auto/injector.js#L923-L926
