### PR TITLE
#81 - Move angular types to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "@types/react-dom": ">=16",
     "prop-types": ">=15",
     "react": ">=15",
-    "react-dom": ">=15"
+    "react-dom": ">=15",
+    "@types/angular": ">=1.5",
   },
   "devDependencies": {
     "@types/angular-mocks": "^1.5.11",
@@ -68,10 +69,10 @@
     "rollupify": "^0.4.0",
     "tslint": "^5.9.1",
     "typescript": "^2.7.1",
-    "watchify": "^3.10.0"
+    "watchify": "^3.10.0",
+    "@types/angular": ">=1.5",
   },
   "dependencies": {
-    "@types/angular": ">=1.5",
     "@types/lodash.frompairs": "^4.0.3",
     "angular": ">=1.5",
     "lodash.frompairs": "^4.0.1",


### PR DESCRIPTION
So it will not force consumers to use angular types (In case of using custom types file)