### PR TITLE
Remove @types packages from peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,11 +36,6 @@
   },
   "homepage": "https://github.com/coatue-oss/react2angular#readme",
   "peerDependencies": {
-    "@types/angular": ">=1.5",
-    "@types/prop-types": ">=15",
-    "@types/react": ">=16",
-    "@types/react-dom": ">=16",
-    "prop-types": ">=15",
     "react": ">=15",
     "react-dom": ">=15"
   },


### PR DESCRIPTION
This project uses typescript in its development - but by the time it's published to NPM, it's compiled down to vanilla JS. The @types packages which were specified in peerDependencies would be useful for consumers that use typescript, but: 
1. those users will already know to install those @types packages, because that's how React and
Angular get their types, and 
2. the users who _don't_ use typescript will get warnings 

Those types are more accurately peer dependencies _for React and Angular_, and _only when typescript is in use_. They probably don't belong on this package, which simply uses whatever version of React and Angular it gets.

In order to kill off those extraneous warnings, I've removed those packages from peerDependencies. It should have no impact on the package itself, only the warnings produced when installed.